### PR TITLE
ci: Add permissions to all GH Actions workflows.

### DIFF
--- a/.github/workflows/docs_publish.yaml
+++ b/.github/workflows/docs_publish.yaml
@@ -4,6 +4,9 @@ name: "03 - Publish Docs"
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   #publish:
   #  uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15

--- a/.github/workflows/release_version_check.yaml
+++ b/.github/workflows/release_version_check.yaml
@@ -1,8 +1,10 @@
 name: "05 - Release Version Check"
-
 "on":
   schedule:
     - cron: 0 0 * * *
+
+permissions:
+  contents: read
 
 jobs:
   verscheck:
@@ -30,4 +32,3 @@ jobs:
           footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-

--- a/.github/workflows/sdk_generation.yaml
+++ b/.github/workflows/sdk_generation.yaml
@@ -1,9 +1,4 @@
 name: "02 - Generate"
-permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
 "on":
   workflow_dispatch:
     inputs:
@@ -13,6 +8,13 @@ permissions:
         default: false
   schedule:
     - cron: 0 0 * * 0
+
+permissions:
+  checks: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
 jobs:
   generate:
     runs-on: ubuntu-latest

--- a/.github/workflows/sdk_publish.yaml
+++ b/.github/workflows/sdk_publish.yaml
@@ -11,7 +11,12 @@ name: "04 - Publish to Maven Central and GitHub Release"
       - main
     paths:
       - RELEASES.md
-      - '*/RELEASES.md'
+      - "*/RELEASES.md"
+
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   test_and_lint:
     runs-on: ubuntu-latest
@@ -82,4 +87,3 @@ jobs:
           footer: "Linked Repo <{repo_url}|{repo}> | <{run_url}|View Run>"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-

--- a/.github/workflows/test_and_lint.yaml
+++ b/.github/workflows/test_and_lint.yaml
@@ -1,6 +1,10 @@
 name: "01 - Run unit tests and lint Java code"
-on:
+"on":
   pull_request:
+
+permissions:
+  contents: read
+  checks: write
 
 jobs:
   test_and_lint:
@@ -13,7 +17,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: success() || failure() # always run even if the previous step fails
         with:
-          report_paths: '**/build/test-results/test/TEST-*.xml' 
+          report_paths: "**/build/test-results/test/TEST-*.xml"
       - name: Publish Checkstyle report
         uses: Juuxel/publish-checkstyle-report@v1
         if: ${{ failure() || success() }}


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

We've got some warnings from the CodeQL scanners about lack of explicit permissions for the Github Token in most of the repo's GH Actions workflow files. This PR adds explicit `permissions: ...` blocks to solve that problem.

This PR also may fix some permissions-based issues in the test suite that were spitting out non-fatal errors.

### :athletic_shoe: How to test

 - CI runs successfully for this PR.
   - if we need to tweak permissions further in the future, it may be easier, due to the defaults being explicit now.

### :chains: Related Resources

