### PR TITLE
pkg: Fix groupID nesting.

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -37,7 +37,7 @@ java:
   defaultErrorName: SDKError
   flattenGlobalSecurity: false
   githubURL: github.com/open-policy-agent/opa-java
-  groupID: io.github.open-policy-agent.opa
+  groupID: io.github.open-policy-agent
   imports:
     option: openapi
     paths:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # OPA Java SDK
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Maven Central Version](https://img.shields.io/maven-central/v/io.github.open_policy_agent.opa/opa?label=Maven%20Central&logo=apache-maven&color=%2324b6e0)](https://central.sonatype.com/artifact/io.github.open_policy_agent.opa/opa)
+[![Maven Central Version](https://img.shields.io/maven-central/v/io.github.open_policy_agent/opa?label=Maven%20Central&logo=apache-maven&color=%2324b6e0)](https://central.sonatype.com/artifact/io.github.open_policy_agent/opa)
 
 > [!IMPORTANT]
 > The documentation for this SDK lives at [`docs/`](https://github.com/open-policy-agent/opa-java/tree/main/docs), with reference documentation available at https://open-policy-agent.github.io/opa-java/javadoc, and development documentation at https://open-policy-agent.github.io/opa-java/
@@ -10,7 +10,7 @@ You can use the OPA Java SDK to connect to [Open Policy Agent](https://www.openp
 
 ## SDK Installation
 
-This package is published on Maven Central as [`io.github.open_policy_agent.opa/opa`](https://central.sonatype.com/artifact/io.github.open_policy_agent.opa/opa/overview). The Maven Central page includes up-to-date instructions to add it as a dependency to your Java project, tailored for a variety of build systems including Maven and Gradle.
+This package is published on Maven Central as [`io.github.open_policy_agent/opa`](https://central.sonatype.com/artifact/io.github.open_policy_agent/opa/overview). The Maven Central page includes up-to-date instructions to add it as a dependency to your Java project, tailored for a variety of build systems including Maven and Gradle.
 
 If you wish to build from source and publish the SDK artifact to your local Maven repository (on your filesystem) then use the following command (after cloning the git repo locally):
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ jar {
     dependsOn(":generatePomFileForMavenPublication")
     archiveBaseName = "${artifactId}"
 
-    into("META-INF/maven/io.github.open-policy-agent.opa/opa") {
+    into("META-INF/maven/io.github.open-policy-agent/opa") {
         from("$buildDir/pom.xml")
     }
 }
@@ -104,7 +104,7 @@ publishing {
         maven(MavenPublication) {
             // note that properties can't yet be used below!
             // https://github.com/gradle/gradle/issues/18619
-            groupId = "io.github.open-policy-agent.opa"
+            groupId = "io.github.open-policy-agent"
             artifactId = "opa"
             version = "2.1.1"
 

--- a/scripts/fix-build-gradle.sh
+++ b/scripts/fix-build-gradle.sh
@@ -84,9 +84,9 @@ ensure_plugin 'id "nebula.lint".*' 'id "nebula.lint" version "17.8.0"' './build.
 
 # Rewrite the artifact and group ID to be one level "up", so we publish
 # io.github.open_policy_agent.opa rather than io.github.open_policy_agent.opa.openapi.
-"$SED" 's#into("META-INF/maven/io.github.open_policy_agent.opa/openapi")#into("META-INF/maven/io.github.open-policy-agent.opa/opa")#g' < build.gradle | \
-	"$SED" 's#group = "io.github.open_policy_agent.opa"#group = "io.github.open-policy-agent.opa"#g' | \
-	"$SED" 's#groupId = "io.github.open_policy_agent.opa"#groupId = "io.github.open-policy-agent.opa"#g' | \
+"$SED" 's#into("META-INF/maven/io.github.open_policy_agent.opa/openapi")#into("META-INF/maven/io.github.open-policy-agent/opa")#g' < build.gradle | \
+	"$SED" 's#group = "io.github.open_policy_agent.opa"#group = "io.github.open-policy-agent"#g' | \
+	"$SED" 's#groupId = "io.github.open_policy_agent.opa"#groupId = "io.github.open-policy-agent"#g' | \
 	"$SED" 's#artifactId = "openapi"#artifactId = "opa"#g' | \
 	"$SED" 's#archiveBaseName = "openapi"#archiveBaseName = "opa"#g' | \
 	"$SED" 's#libs/openapi-#libs/opa-#g' > build.gradle.tmp
@@ -101,7 +101,7 @@ mv build.gradle.tmp build.gradle
 "$SED" -i "s/rootProject[.]name = 'openapi'/rootProject.name = 'opa'/g" ./settings.gradle
 
 # Update gradle.properties to set the groupId and artifactId
-"$SED" -i "s/groupId=io.github.open_policy_agent.opa/groupId=io.github.open-policy-agent.opa/g" ./gradle.properties
+"$SED" -i "s/groupId=io.github.open_policy_agent.opa/groupId=io.github.open-policy-agent/g" ./gradle.properties
 "$SED" -i "s/artifactId=openapi/artifactId=opa/g" ./gradle.properties
 
 


### PR DESCRIPTION
### :nut_and_bolt: What code changed, and why?

This PR adjusts the prefix for the artifact to be just `io.github.open-policy-agent`, instead of `io.github.open-policy-agent.opa`.

The previous PR, #96, did get a deployment to appear on Maven Central, but the groupID bits were wrong, causing verification failures.
